### PR TITLE
Allow all usernames to be used

### DIFF
--- a/util.go
+++ b/util.go
@@ -5,15 +5,7 @@ import "unicode"
 // IsValidCSid returns true if the given string contains a valid
 // username used at UBC CS.
 func IsValidCSid(id string) bool {
-	if len(id) != 4 && len(id) != 5 {
-		return false
-	}
-	for i, char := range id {
-		if i%2 == 0 && !unicode.IsLetter(char) {
-			return false
-		} else if i%2 != 0 && !unicode.IsDigit(char) {
-			return false
-		}
-	}
+	// TODO: we can get rid of this function, as all strings are
+	// valid usernames now.
 	return true
 }

--- a/util.go
+++ b/util.go
@@ -1,7 +1,5 @@
 package main
 
-import "unicode"
-
 // IsValidCSid returns true if the given string contains a valid
 // username used at UBC CS.
 func IsValidCSid(id string) bool {


### PR DESCRIPTION
UBC CS IDs no longer have restrictions on the character set, allow all.